### PR TITLE
yii-params improvement + unify imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,18 +49,24 @@ Configure api tokens component (e.g. common/config/main.php):
 ```php
 return [
     'components' => [
-        'apiTokens'      => [
-            'class'     => \Kakadu\Yii2JwtAuth\ApiTokenService::class,
-            'secretKey' => '', // set in main-local.php
-            'issuer'    => 'you-domain-name', // or yii-params.domain
-            'audience'  => ['you-domain-name'], // or yii-params.domain
-            'seamlessLogin' => false,
+        'apiTokens' => [
+            'class'           => \Kakadu\Yii2JwtAuth\ApiTokenService::class,
+            'secretKey'       => '', // set in main-local.php or yii-params.domainSecretKey
+            'issuer'          => 'you-domain-name', // or yii-params.domain
+            'audience'        => ['you-domain-name', 'second-domain-name'], // or yii-params.domain
+            'audienceSecrets' => [
+                'you-domain-name'    => '', // or yii-params.domainSecretKey
+                'second-domain-name' => '', // or yii-params.secondDomainSecretKey
+            ],
+            'seamlessLogin'   => false,
         ],
     ],
 ];
 ```
 
-All values in _issuer_, _audience_, _audienceSecrets_ which contain _yii-params.param-name_ will be converted to Yii::$app->params['param-name']
+All values in _secretKey_, _issuer_, _audience_, _audienceSecrets_ which contain _yii-params.param-name_ will be converted to Yii::$app->params['param-name']
+
+TBD: add example for `yii-params.*` config (e.g. for `audienceSecrets`).
 
 Now, after user registration, create JWT tokens and add their in response headers. 
 Also add an action to update tokens.  

--- a/src/ApiTokenService.php
+++ b/src/ApiTokenService.php
@@ -10,7 +10,11 @@ namespace Kakadu\Yii2JwtAuth;
 
 use Firebase\JWT\ExpiredException;
 use Firebase\JWT\JWT;
+use UnexpectedValueException;
+use Yii;
 use yii\base\Component;
+use yii\base\InvalidConfigException;
+use yii\db\Exception;
 use yii\di\Instance;
 use yii\log\Dispatcher;
 use yii\log\Logger;
@@ -101,7 +105,7 @@ class ApiTokenService extends Component
      *
      * @param array $config
      *
-     * @throws \yii\base\InvalidConfigException
+     * @throws InvalidConfigException
      */
     public function __construct(array $config = [])
     {
@@ -120,7 +124,7 @@ class ApiTokenService extends Component
      * @param array $params
      *
      * @return ApiToken|null
-     * @throws \yii\db\Exception
+     * @throws Exception
      */
     public function create(int $userId, array $params = []): ?ApiToken
     {
@@ -207,7 +211,7 @@ class ApiTokenService extends Component
         $inParams = explode('yii-params.', $this->issuer);
 
         if (!empty($inParams[1])) {
-            return \Yii::$app->params[$inParams[1]] ?? $this->issuer;
+            return Yii::$app->params[$inParams[1]] ?? $this->issuer;
         }
 
         return $this->issuer;
@@ -227,7 +231,7 @@ class ApiTokenService extends Component
                 $inParams = explode('yii-params.', $item);
 
                 if (!empty($inParams[1])) {
-                    $item = \Yii::$app->params[$inParams[1]] ?? $item;
+                    $item = Yii::$app->params[$inParams[1]] ?? $item;
                 }
             }
         }
@@ -249,7 +253,7 @@ class ApiTokenService extends Component
 
             if (!empty($inParams[1])) {
                 unset($audienceSecrets[$item]);
-                $audienceSecrets[\Yii::$app->params[$inParams[1]] ?? $item] = $value;
+                $audienceSecrets[Yii::$app->params[$inParams[1]] ?? $item] = $value;
             }
         }
 
@@ -288,6 +292,7 @@ class ApiTokenService extends Component
      * @param JwtToken $refreshToken
      *
      * @return ApiToken|null
+     * @throws Exception
      */
     public function renewJwtToken(JwtToken $accessToken, JwtToken $refreshToken): ?ApiToken
     {
@@ -337,7 +342,7 @@ class ApiTokenService extends Component
     private function decodeJwt(string $jwtToken = null): array
     {
         if (!$jwtToken) {
-            throw new \UnexpectedValueException('Empty jwt');
+            throw new UnexpectedValueException('Empty jwt');
         }
 
         $secretKey = $this->secretKey;
@@ -352,7 +357,7 @@ class ApiTokenService extends Component
             if ((is_string($allowAud) && $allowAud !== $issuer)
                 || (is_array($allowAud) && !in_array($issuer, $allowAud, true))
             ) {
-                throw new \UnexpectedValueException('Invalid issuer');
+                throw new UnexpectedValueException('Invalid issuer');
             }
 
             $audSecrets = $this->getAudienceSecrets();
@@ -380,7 +385,7 @@ class ApiTokenService extends Component
 
         if (empty($tks[1])) {
             if ($throwErrors) {
-                throw new \UnexpectedValueException('Wrong number of segments');
+                throw new UnexpectedValueException('Wrong number of segments');
             }
 
             return [];
@@ -388,7 +393,7 @@ class ApiTokenService extends Component
 
         $payload = JWT::jsonDecode(JWT::urlsafeB64Decode($tks[1]));
         if ($payload === null && $throwErrors) {
-            throw new \UnexpectedValueException('Invalid claims encoding');
+            throw new UnexpectedValueException('Invalid claims encoding');
         }
 
         return (array) $payload;

--- a/src/ApiTokenService.php
+++ b/src/ApiTokenService.php
@@ -400,21 +400,21 @@ class ApiTokenService extends Component
      *
      * @param string|null $jwtToken
      *
-     * @return bool
+     * @return int number of deleted tokens, may be 0
      */
-    public function deleteToken(string $jwtToken = null): bool
+    public function deleteToken(string $jwtToken = null): int
     {
         return ApiToken::deleteAll([
-                'OR',
-                ['access_token' => $jwtToken],
-                ['refresh_token' => $jwtToken],
-                // Delete expired tokens
-                $this->deleteExpired ? [
-                    'AND',
-                    ['<=', 'refresh_expires', time()],
-                    ['!=', 'refresh_expires', 0],
-                ] : [],
-            ]) > 0;
+            'OR',
+            ['access_token' => $jwtToken],
+            ['refresh_token' => $jwtToken],
+            // Delete expired tokens
+            $this->deleteExpired ? [
+                'AND',
+                ['<=', 'refresh_expires', time()],
+                ['!=', 'refresh_expires', 0],
+            ] : [],
+        ]);
     }
 
     /**

--- a/src/JwtBearerAuth.php
+++ b/src/JwtBearerAuth.php
@@ -8,6 +8,8 @@
 
 namespace Kakadu\Yii2JwtAuth;
 
+use yii\base\InvalidConfigException;
+use yii\db\Exception;
 use yii\di\Instance;
 use yii\filters\auth\HttpBearerAuth;
 use yii\web\Request;
@@ -78,7 +80,7 @@ class JwtBearerAuth extends HttpBearerAuth
 
     /**
      * @inheritdoc
-     * @throws \yii\base\InvalidConfigException
+     * @throws InvalidConfigException
      */
     public function init(): void
     {
@@ -89,6 +91,7 @@ class JwtBearerAuth extends HttpBearerAuth
 
     /**
      * @inheritdoc
+     * @throws Exception
      */
     public function authenticate($user, $request, $response)
     {
@@ -171,10 +174,11 @@ class JwtBearerAuth extends HttpBearerAuth
     /**
      * Force renew existed token.
      *
-     * @param Request  $request
+     * @param Request $request
      * @param Response $response
      *
      * @return bool
+     * @throws Exception
      */
     public function renewToken(Request $request, Response $response): bool
     {

--- a/src/RefreshTokensAction.php
+++ b/src/RefreshTokensAction.php
@@ -9,6 +9,8 @@
 namespace Kakadu\Yii2JwtAuth;
 
 use yii\base\Action;
+use yii\base\InvalidConfigException;
+use yii\db\Exception;
 use yii\di\Instance;
 use yii\web\Request;
 use yii\web\Response;
@@ -54,7 +56,7 @@ class RefreshTokensAction extends Action
 
     /**
      * @inheritdoc
-     * @throws \yii\base\InvalidConfigException
+     * @throws InvalidConfigException
      */
     public function init(): void
     {
@@ -68,11 +70,12 @@ class RefreshTokensAction extends Action
     /**
      * Renew tokens
      *
-     * @return void
+     * @throws UnauthorizedHttpException
+     * @throws Exception
      */
     public function run(): void
     {
-        list('accessToken' => $accessToken, 'refreshToken' => $refreshToken) = $this->getTokens();
+        ['accessToken' => $accessToken, 'refreshToken' => $refreshToken] = $this->getTokens();
 
         // Convert to jwt token model
         $jwtAccessToken  = $this->apiTokens->getJwtToken($accessToken);


### PR DESCRIPTION
token service: unify getting value for properties from `Yii::$app->params` and add support for `secretKey`
token service: `ActiveRecord::deleteAll()` may return 0 wich also means successful operation
add missing throw tags and unify `\Yii` and exceptions' imports
add TBD for audienceSecrets+yii-params usage example